### PR TITLE
EC2用に初期設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,10 @@ group :test do
   gem 'faker'
 end
 
+group :production do
+  gem 'unicorn', '5.4.1'
+end
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    kgio (2.11.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -161,6 +162,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.19.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -222,6 +224,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unicorn (5.4.1)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -262,6 +267,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  unicorn (= 5.4.1)
   web-console (>= 3.3.0)
 
 BUNDLED WITH

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,55 @@
+#サーバ上でのアプリケーションコードが設置されているディレクトリを変数に入れておく
+app_path = File.expand_path('../../', __FILE__)
+
+#アプリケーションサーバの性能を決定する
+worker_processes 1
+
+#アプリケーションの設置されているディレクトリを指定
+working_directory app_path
+
+#Unicornの起動に必要なファイルの設置場所を指定
+pid "#{app_path}/tmp/pids/unicorn.pid"
+
+#ポート番号を指定
+listen 3000
+
+#エラーのログを記録するファイルを指定
+stderr_path "#{app_path}/log/unicorn.stderr.log"
+
+#通常のログを記録するファイルを指定
+stdout_path "#{app_path}/log/unicorn.stdout.log"
+
+#Railsアプリケーションの応答を待つ上限時間を設定
+timeout 60
+
+#以下は応用的な設定なので説明は割愛
+
+preload_app true
+GC.respond_to?(:copy_on_write_friendly=) && GC.copy_on_write_friendly = true
+
+check_client_connection false
+
+run_once = true
+
+before_fork do |server, worker|
+  defined?(ActiveRecord::Base) &&
+    ActiveRecord::Base.connection.disconnect!
+
+  if run_once
+    run_once = false # prevent from firing again
+  end
+
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exist?(old_pid) && server.pid != old_pid
+    begin
+      sig = (worker.nr + 1) >= server.worker_processes ? :QUIT : :TTOU
+      Process.kill(sig, File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH => e
+      logger.error e
+    end
+  end
+end
+
+after_fork do |_server, _worker|
+  defined?(ActiveRecord::Base) && ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
WHAT
EC2用に初期設定する

WHY
EC2用にunicornなどを初期設定する必要があるため